### PR TITLE
Fix vercel function runtime version error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,4 @@
 {
-  "functions": {
-    "src/**/*.{js,ts,tsx}": {
-      "runtime": "@vercel/node@3"
-    }
-  },
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist",
   "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",


### PR DESCRIPTION
Resolve Vercel runtime error by removing the `functions` section from `vercel.json`.

This allows Vercel to automatically detect the project type and use the appropriate runtime, as explicit serverless function configuration is unnecessary for this project (likely a static site or SPA).

---
[Slack Thread](https://nidomi-io.slack.com/archives/C098C30B3AP/p1754025138279599?thread_ts=1754025138.279599&cid=C098C30B3AP)

<a href="https://cursor.com/background-agent?bcId=bc-27e3b633-2e59-4a7c-b5cc-6132d6979091">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27e3b633-2e59-4a7c-b5cc-6132d6979091">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>